### PR TITLE
Add option to install edge and add namespace

### DIFF
--- a/gloo-edge/argo/oss/1.9.7/gloo-edge-oss-helm-plus-ns-1-9-7.yaml
+++ b/gloo-edge/argo/oss/1.9.7/gloo-edge-oss-helm-plus-ns-1-9-7.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gloo-system
+spec:
+  finalizers:
+  - kubernetes
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gloo-edge-oss-helm-1-9-7
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/solo-io/gitops-library
+    targetRevision: HEAD
+    path: gloo-edge/base/oss/1-9-7/
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: gloo-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Adding an option to add namespace creation to Gloo Edge application manifest, rather than requiring `kubectl` to add it manually.